### PR TITLE
fix: add email as a fake value option

### DIFF
--- a/src/anonymizers/fake/fake-anonymizer.ts
+++ b/src/anonymizers/fake/fake-anonymizer.ts
@@ -25,6 +25,8 @@ export class FakeAnonymizer extends BaseAnonymizer {
 				return chance.name();
 			case 'animal':
 				return chance.animal();
+			case 'email':
+				return chance.email();
 			default:
 				break;
 		}

--- a/src/anonymizers/fake/types.ts
+++ b/src/anonymizers/fake/types.ts
@@ -1,5 +1,6 @@
 export const fakeTypes: string[] = [
 	'age',
+	'email',
 	'first',
 	'firstName',
 	'last',
@@ -12,6 +13,7 @@ export const fakeTypes: string[] = [
 export type FakeType =
 	| 'age'
 	| 'animal'
+	| 'email'
 	| 'first'
 	| 'firstName'
 	| 'last'

--- a/website/docs/providers/fake.md
+++ b/website/docs/providers/fake.md
@@ -21,9 +21,11 @@ Generates fake data instead of the previous value
    5. `letter` - a single letter
    6. `name` - full name
    7. `word` - random word
+   8. `email`
 
 ## Examples
 
 ```
 { 'firstName': 'John'} => { 'firstName': 'Random'}
+{ 'email': 'jsmith@business.org'} => { 'email': 'awkir@ptknolyoj.gov'}
 ```


### PR DESCRIPTION
Adds `email` as a fake value option to the fake provider, and also updates the docs accordingly.